### PR TITLE
fix(results): results now display regardless of where you come from. …

### DIFF
--- a/angular-src/src/app/components/results/results.component.html
+++ b/angular-src/src/app/components/results/results.component.html
@@ -1,63 +1,66 @@
 <h1>Search Results</h1>
 <mat-paginator [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons></mat-paginator>
-<table class="mat-elevation-z8 results-table" mat-table [dataSource]="storedResults"  matSort>
-    <ng-container matColumnDef="title">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Title</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.title }}
-          <button mat-raised-button (click)="showMovieModal(movie)">See Movie Info</button>
-        </td>
-    </ng-container>
-    <ng-container matColumnDef="tagline">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Tagline</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.tagline }}</td>
-    </ng-container>
-    <ng-container matColumnDef="release_date">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Release Date</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.release_date | date }}</td>
-    </ng-container>
-    <ng-container matColumnDef="original_title">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Original Title</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.original_title }}</td>
-    </ng-container>
-    <ng-container matColumnDef="budget">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Budget</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.budget | currency:'USD' }}</td>
-    </ng-container>
-    <ng-container matColumnDef="revenue">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Revenue</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.revenue | currency:'USD' }}</td>
-    </ng-container>
-    <ng-container matColumnDef="runtime">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Run Time</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.runtime }}</td>
-    </ng-container>
-    <ng-container matColumnDef="overview">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Overview</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.overview }}</td>
-    </ng-container>
-    <ng-container matColumnDef="popularity">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Popularity</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.popularity }}</td>
-    </ng-container>
-    <ng-container matColumnDef="adult">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Adult?</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.adult && 'Yes' || 'No' }}</td>
-    </ng-container>
-    <ng-container matColumnDef="vote_average">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Vote Average</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.vote_average }}</td>
-    </ng-container>
-    <ng-container matColumnDef="vote_count">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Vote Count</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.vote_count}}</td>
-    </ng-container>
-    <ng-container matColumnDef="movie_id">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Movie ID</th>
-        <td mat-cell *matCellDef="let movie">{{ movie?.movie_id }}</td>
-    </ng-container>
-    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
-    <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
-</table>
+<div *ngIf="storedResults">
+    <table class="mat-elevation-z8 results-table" mat-table [dataSource]="storedResults"  matSort>
+        <ng-container matColumnDef="title">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Title</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.title }}
+              <button mat-raised-button (click)="showMovieModal(movie)">See Movie Info</button>
+            </td>
+        </ng-container>
+        <ng-container matColumnDef="tagline">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Tagline</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.tagline }}</td>
+        </ng-container>
+        <ng-container matColumnDef="release_date">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Release Date</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.release_date | date }}</td>
+        </ng-container>
+        <ng-container matColumnDef="original_title">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Original Title</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.original_title }}</td>
+        </ng-container>
+        <ng-container matColumnDef="budget">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Budget</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.budget | currency:'USD' }}</td>
+        </ng-container>
+        <ng-container matColumnDef="revenue">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Revenue</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.revenue | currency:'USD' }}</td>
+        </ng-container>
+        <ng-container matColumnDef="runtime">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Run Time</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.runtime }}</td>
+        </ng-container>
+        <ng-container matColumnDef="overview">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Overview</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.overview }}</td>
+        </ng-container>
+        <ng-container matColumnDef="popularity">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Popularity</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.popularity }}</td>
+        </ng-container>
+        <ng-container matColumnDef="adult">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Adult?</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.adult && 'Yes' || 'No' }}</td>
+        </ng-container>
+        <ng-container matColumnDef="vote_average">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Vote Average</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.vote_average }}</td>
+        </ng-container>
+        <ng-container matColumnDef="vote_count">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Vote Count</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.vote_count}}</td>
+        </ng-container>
+        <ng-container matColumnDef="movie_id">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Movie ID</th>
+            <td mat-cell *matCellDef="let movie">{{ movie?.movie_id }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+        <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
+    </table>
+    
+</div>
 
 <!-- <pre *ngIf="storedResults">
     {{ storedResults | json }}

--- a/angular-src/src/app/components/results/results.component.ts
+++ b/angular-src/src/app/components/results/results.component.ts
@@ -15,6 +15,7 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 export class ResultComponent implements OnInit {
 
     public storedResults: any;
+    private _rawResults:any;
     public resultSub: Subscription;
     public columnsToDisplay: String[] = [];
     @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -26,17 +27,13 @@ export class ResultComponent implements OnInit {
     constructor(private _search: SearchService, public dialog: MatDialog) {}
 
     ngOnInit(): void {
-        // this._search.getResults().subscribe(results => this.storedResults = results)
         this._search.resultsSubscription().subscribe(results => {
-            console.log('receiving data', results);
-            this.storedResults = results;
-            console.log('stored results:', this.storedResults);
-            this.storedResults = results.data.result;
+            this._rawResults = results.result;
             // console.log(this.storedResults);
 
             this.columnsToDisplay = [];
-            for (const key in this.storedResults[0]) {
-                if (this.storedResults[0][key]) {
+            for (const key in this._rawResults[0]) {
+                if (this._rawResults[0][key]) {
                     this.columnsToDisplay.push(key);
                     console.log('pushing...', key);
                 }
@@ -48,7 +45,7 @@ export class ResultComponent implements OnInit {
 
                 return subjectOrder.indexOf(a) - subjectOrder.indexOf(b);
             });
-            this.storedResults = new MatTableDataSource<IMovie>(this.storedResults);
+            this.storedResults = new MatTableDataSource<IMovie>(this._rawResults);
             // console.log('sort', this.sort);
             this.storedResults.sort = this.sort;
             this.storedResults.paginator = this.paginator;

--- a/angular-src/src/app/services/search.service.ts
+++ b/angular-src/src/app/services/search.service.ts
@@ -48,7 +48,7 @@ export class SearchService {
 
     public storeResults(data:any) {
         this.storedSearchData = data;
-        this.searchSubj.next({data})
+        this.searchSubj.next(data)
     }
 
     public refreshResults() {


### PR DESCRIPTION
…empty table no longer displays

🐛 Bug Fix 🐛 
The results weren't properly being displayed due to the result object being sent two different ways depending on what event triggered the subscription to emit. That's fixed now.
Also, I wrapped the table in a `<div>` with an `*ngIf` to prevent an empty table from showing up. Angular Material does not like `*ngIf` on the table itself.