### PR TITLE
chore(api): created endpoint that creates a query as sends it back as…

### DIFF
--- a/angular-src/src/app/components/adv-search/adv-search.component.ts
+++ b/angular-src/src/app/components/adv-search/adv-search.component.ts
@@ -77,6 +77,18 @@ export class AdvSearchComponent {
 
     public submit(value) {
         console.log('submitting...', value, this.requestedColumns);
+        if (value.returnType === 'table') {
+            this.tableSearch(value);
+        } else if (value.returnType === 'cards') {
+            this.cardSearch(value);
+        }
+    }
+
+    public tableSearch(value) {
+
+    }
+
+    public cardSearch(value) {
     }
 
 }

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -6,6 +6,7 @@ import { search } from "./endpoints/search-title-endpoint";
 import { topTen } from "./endpoints/top-10-vote-endpoint";
 import { getByYear } from "./endpoints/get-by-year-endpoint";
 import { testJoin } from "./endpoints/test-join";
+import { categorySearch } from "./endpoints/custom-queries/search-by-category-endpoint";
 
 export function initAPI (app:Application) {
     app.route('/api/test').get(testEndpoint);
@@ -18,4 +19,6 @@ export function initAPI (app:Application) {
     app.route('/api/get-by-year').post(getByYear);
 
     app.route('/api/join-test').post(testJoin);
+
+    app.route('/api/custom-search').post(categorySearch);
 }

--- a/server/api/endpoints/custom-queries/search-by-category-endpoint.ts
+++ b/server/api/endpoints/custom-queries/search-by-category-endpoint.ts
@@ -1,0 +1,53 @@
+import { Request, Response, NextFunction } from 'express';
+import * as db from './../../../db/db';
+
+export async function categorySearch(req: Request, res: Response, next: NextFunction) {
+    try {
+        // whitelist column values to prevent injection since we're concating
+        const acceptableColumns = ['budget', 'movie_id', 'original_title', 'overview', 'popularity', 'release_date', 'revenue', 'runtime', 'tagline', 'title', 'vote_average', 'vote_count'];
+        if(!req.body.category || !req.body.search || !req.body.order) {
+            // make sure fields arent missing
+            res.status(400).json({message: "Missing Fields"});
+        } else if (req.body.order !== 'ASC' && req.body.order !== 'DESC') {
+            // white list order since thats being concated as well
+            res.status(400).json({message: "Invalid Order"});
+        } else if ( typeof req.body.category !== 'string' || acceptableColumns.indexOf(req.body.category) < 0 ) {
+            // make sure category is both a  string and in our whitelist
+            res.status(400).json({message: "Invalid Column Name"})
+        } else {
+            // build our query, log it, and execute
+            const query = buildQuery(req);
+            console.log('Query: ', query);
+            db.any(query, req.body.search).then( (resp) => {
+                // return all relevant info for the storing of the query
+                res.json({
+                    message: "Search results",
+                    result: resp,
+                    query: query,
+                    category: req.body.category,
+                    search: req.body.search
+                })
+            }).catch(err => res.status(500).json({message: "Error", error: err}));
+        }
+    } catch (err) {
+        res.json({message: "Error", error: err})
+    }
+    
+    
+}
+
+function buildQuery(req: Request) {
+    if (!req.body || !req.body.category) {return null}
+    let result:string = null;
+    switch (req.body.category) {
+        case 'release_date':
+            // release date requires an extraction of the year and exact matching it to the search value
+            result = "SELECT * FROM movies_meta WHERE EXTRACT (YEAR FROM release_date) = $1 ";
+            break;
+        default:
+            // default query takes in a category and returning any record that contains the search value
+            result = `SELECT * FROM movies_meta WHERE LOWER (${req.body.category}) LIKE LOWER( \'%$1#%\' ) ORDER BY COALESCE(${req.body.category}, null) ${req.body.order}`
+            break;
+    }
+    return result;
+}


### PR DESCRIPTION
… part of the result"

Custom Queries! :tada:
You can now hit an endpoint `custom-search` which will require three properties in the request body: `category`, `search` and `order`. A query will be built that searches the main table (for now, will do an outer join with credits soon) searching for the value of `search` inside the column `category`.  In addition to the result, the query along with relevant information for repeating the same query will be returned that will likely go to @brandynm34 's service. 