### PR TITLE
chore(api): added endpoint for actor search

### DIFF
--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -7,6 +7,7 @@ import { topTen } from "./endpoints/top-10-vote-endpoint";
 import { getByYear } from "./endpoints/get-by-year-endpoint";
 import { testJoin } from "./endpoints/test-join";
 import { categorySearch } from "./endpoints/custom-queries/search-by-category-endpoint";
+import { actorSearch } from "./endpoints/join-queries/actor-search-endpoint";
 
 export function initAPI (app:Application) {
     app.route('/api/test').get(testEndpoint);
@@ -19,6 +20,7 @@ export function initAPI (app:Application) {
     app.route('/api/get-by-year').post(getByYear);
 
     app.route('/api/join-test').post(testJoin);
+    app.route('/api/actor-search').post(actorSearch);
 
     app.route('/api/custom-search').post(categorySearch);
 }

--- a/server/api/endpoints/join-queries/actor-search-endpoint.ts
+++ b/server/api/endpoints/join-queries/actor-search-endpoint.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction } from 'express';
+import * as db from './../../../db/db';
+
+export async function actorSearch(req: Request, res: Response, next: NextFunction) {
+    try {
+        if(!req.body.search) {
+            // make sure fields arent missing
+            res.status(400).json({message: "Missing Fields"});
+        } else {
+            // build our query, log it, and execute
+            const query = 'SELECT * FROM movies_meta FULL OUTER JOIN movies_credits ON (movie_id = credit_id) WHERE LOWER (movie_cast) LIKE LOWER( \'%$1#%\' )';
+            console.log('Query: ', query);
+            db.any(query, req.body.search).then( (resp) => {
+                // return all relevant info for the storing of the query
+                res.json({
+                    message: "Search results",
+                    result: resp,
+                    query: query,
+                    category: 'cast',
+                    search: req.body.search
+                })
+            }).catch(err => res.status(500).json({message: "Error", error: err}));
+        }
+    } catch (err) {
+        res.json({message: "Error", error: err})
+    }
+    
+    
+}


### PR DESCRIPTION
To demonstrate the ability to search for a column in a secondary table, there is an endpoint to search for an actor. The database then returns information from both tables where the actor search values is contained inside the `movie_cast` string.

Keep in mind that there is not nearly as many entries for the cast and crew as we have movies in the primary tables, therefore not every movie that an actor has appeared in will display.