### PR TITLE
feat(results/revenue): search results can now link to revenue page

### DIFF
--- a/angular-src/src/app/components/results/results.component.html
+++ b/angular-src/src/app/components/results/results.component.html
@@ -1,6 +1,7 @@
 <!-- <h1>Search Results</h1> -->
 <button *ngIf="storedResults" (click)="tableView()" mat-raised-button color="primary" class="center-button">Switch to Table View</button>
-<div class="pie" *ngIf="storedResults">
+<button *ngIf="storedResults" routerLink="../revenue" mat-raised-button color="primary" class="center-button">Revenue information</button>
+<!-- <div class="pie" *ngIf="storedResults">
     <ngx-charts-pie-chart
     [scheme]="colorScheme"
     [results]="pieData"
@@ -10,7 +11,7 @@
     [gradient]="gradient"
     (select)="onSelect($event)"
     ></ngx-charts-pie-chart>
-</div>
+</div> -->
 <div class="grid-container">
     <div class="search-result" *ngFor="let result of storedResults?.data">
         <div class="top" (click)="showMovieModal(result)">

--- a/angular-src/src/app/components/results/results.component.ts
+++ b/angular-src/src/app/components/results/results.component.ts
@@ -87,7 +87,7 @@ export class ResultComponent implements OnInit {
                 this.pieData[0].value++;
             }
         });
-        console.log('pie data', this.pieData);
+        // console.log('pie data', this.pieData);
         Object.assign(this, this.pieData)
     }
 

--- a/angular-src/src/app/components/revenue-component/revenue.component.html
+++ b/angular-src/src/app/components/revenue-component/revenue.component.html
@@ -15,7 +15,7 @@
         <p>Select a starting year and an ending year and see some nifty revenue information about that time period.</p>
     </div>
 </div>
-<button mat-raised-button color="primary" (click)="toggleDisplay()" class="toggle-year hide-stuff">Input New Years</button>
+<button mat-raised-button color="primary" (click)="toggleDisplay(true)" class="toggle-year hide-stuff">Input New Years</button>
 <div class="results-field" *ngIf="this.showResults">
         <div class="pie">
             <ngx-charts-advanced-pie-chart

--- a/angular-src/src/app/components/revenue-component/revenue.component.scss
+++ b/angular-src/src/app/components/revenue-component/revenue.component.scss
@@ -5,7 +5,7 @@ h1 {
 .revenue-top-row {
     display: flex;
     height: 400px;
-    transition: 0.5 all;
+    transition: 0.5s all;
 }
 
 .date-picker {
@@ -44,7 +44,7 @@ h1 {
 }
 
 .revenue-desc {
-    width: 70&;
+    width: 70%;
     min-width: 350px;
     height: 100%;
     display: flex;

--- a/angular-src/src/app/components/revenue-component/revenue.component.ts
+++ b/angular-src/src/app/components/revenue-component/revenue.component.ts
@@ -69,7 +69,7 @@ export class RevenueComponent implements OnInit {
 
     ngOnInit(): void {
         this._search.resultsSubscription().subscribe(response => {
-            console.log('search results from service', response);
+            // console.log('search results from service', response);
             if (response.result) {
                 this.searchResults = response.result;
                 this.toggleDisplay();
@@ -102,7 +102,7 @@ export class RevenueComponent implements OnInit {
         } );
         const firstYear = new Date(searchData[0].release_date);
         const lastYear = new Date (searchData[searchData.length - 1].release_date);
-        console.log(`start year: ${firstYear.getFullYear()}, end year: ${lastYear.getFullYear()}`);
+        // console.log(`start year: ${firstYear.getFullYear()}, end year: ${lastYear.getFullYear()}`);
         return {start: firstYear.getFullYear(), end: lastYear.getFullYear()}
     }
 

--- a/angular-src/src/app/components/revenue-component/revenue.component.ts
+++ b/angular-src/src/app/components/revenue-component/revenue.component.ts
@@ -68,6 +68,16 @@ export class RevenueComponent implements OnInit {
     constructor(private _search: SearchService, public snackBar: MatSnackBar) {}
 
     ngOnInit(): void {
+        this._search.resultsSubscription().subscribe(response => {
+            console.log('search results from service', response);
+            if (response.result) {
+                this.searchResults = response.result;
+                this.toggleDisplay();
+                const years = this._getFirstAndLastYear(response.result)
+                this._initializeGraphs(years.start, years.end, response.result);
+            }
+        });
+        this._search.refreshResults();
     }
 
 
@@ -78,19 +88,39 @@ export class RevenueComponent implements OnInit {
         this.toggleDisplay();
         this._search.getYearRange(yearFormValues.startYear, yearFormValues.endYear).pipe( take(1) ).subscribe(response => {
             this.searchResults = response.result;
-            this.setPieChart();
-            this.topFive = this._getTopFive(this.searchResults);
-            this._organizeBarData(yearFormValues.startYear, yearFormValues.endYear, this.searchResults);
-            this._treeData(this.searchResults);
-            this._heatMapSetup(yearFormValues.startYear, yearFormValues.endYear, this.searchResults);
+            this._initializeGraphs(yearFormValues.startYear, yearFormValues.endYear, this.searchResults);
             // console.log(response);
         });
-       }
-       
-       
+       }    
    }
 
-   public toggleDisplay() {
+    private _getFirstAndLastYear(searchData:IMovie[]) {
+        searchData.sort( (a, b) => {
+            const aDate = new Date(a.release_date);
+            const bDate = new Date(b.release_date);
+            return aDate.getFullYear() - bDate.getFullYear();
+        } );
+        const firstYear = new Date(searchData[0].release_date);
+        const lastYear = new Date (searchData[searchData.length - 1].release_date);
+        console.log(`start year: ${firstYear.getFullYear()}, end year: ${lastYear.getFullYear()}`);
+        return {start: firstYear.getFullYear(), end: lastYear.getFullYear()}
+    }
+
+    private _initializeGraphs(startYear:number, endYear:number, data:IMovie[]) {
+        this.setPieChart();
+        this.topFive = this._getTopFive(data);
+        this._organizeBarData(startYear, endYear, data);
+        this._treeData(data);
+        this._heatMapSetup(startYear, endYear, data);
+    }
+
+   public toggleDisplay(button?: boolean) {
+    //    account for someone coming to the revenue component a second time, but if toggle is triggered from the button, it passes true, skipping this part
+       if (!button && this.searchResults && document.querySelector('.revenue-top-row').classList.contains('hide-stuff')) { 
+            this.showResults = !this.showResults;
+            return; 
+        }
+        
        document.querySelector('.revenue-top-row').classList.toggle('hide-stuff');
        document.querySelector('.toggle-year').classList.toggle('hide-stuff');
        this.showResults = !this.showResults;
@@ -155,6 +185,7 @@ export class RevenueComponent implements OnInit {
                 const dateCheck = new Date(movie.release_date);
                 return dateCheck.getFullYear() === year;
             });
+            if (yearData.length === 0) { continue; }
             let yearlyRevenues:number[] = [];
             yearData.forEach(movie => yearlyRevenues.push(movie.revenue));
             const yearPeak = Math.max(...yearlyRevenues);
@@ -195,6 +226,7 @@ export class RevenueComponent implements OnInit {
                 const dateCheck = new Date(movie.release_date);
                 return dateCheck.getFullYear() === year;
             });
+            if (yearData.length === 0) { continue; }
             let monthlyAverages:number[] = [];
             for (let month = 0; month < 12; month++) {
                 const monthlyData:IMovie[] = yearData.filter( (movie:IMovie) => {
@@ -202,9 +234,14 @@ export class RevenueComponent implements OnInit {
                     return thisMonth.getMonth() === month;
                 } )
                 // console.log('month number', monthlyData);
-                const monthlyRevValues:number[] = monthlyData.map( (movie:IMovie) => movie.revenue );
-                const monthlyAvg:number = monthlyRevValues.reduce( (a, b) => a + b, 0 ) / monthlyRevValues.length;
-                monthlyAverages.push(monthlyAvg);
+                if (!monthlyData || monthlyData.length === 0) {
+                    monthlyAverages.push(0)
+                } else {
+                    const monthlyRevValues:number[] = monthlyData.map( (movie:IMovie) => movie.revenue );
+                    const monthlyAvg:number = monthlyRevValues.reduce( (a, b) => a + b, 0 ) / monthlyRevValues.length;
+                    monthlyAverages.push(monthlyAvg);
+                }
+                
             }
             // console.log('monthly average', monthlyAverages);
             const yearObj = {


### PR DESCRIPTION
There is now a button on the search results page which takes you to the revenue charts retaining the data from the previous charts. I had to adjust the data handling to account for years that have no data.