### PR TITLE
chore(api): custom search now handles all fields. ALL.

### DIFF
--- a/server/api/endpoints/custom-queries/search-by-category-endpoint.ts
+++ b/server/api/endpoints/custom-queries/search-by-category-endpoint.ts
@@ -16,6 +16,7 @@ export async function categorySearch(req: Request, res: Response, next: NextFunc
             res.status(400).json({message: "Invalid Column Name"})
         } else {
             // build our query, log it, and execute
+            req.body.search = [req.body.search]; // push req.body.search into an array so that we can add parameters if necessary
             const query = buildQuery(req);
             console.log('Query: ', query);
             db.any(query, req.body.search).then( (resp) => {
@@ -45,6 +46,18 @@ function buildQuery(req: Request) {
         case 'release_date':
             // release date requires an extraction of the year and exact matching it to the search value
             result = "SELECT * FROM movies_meta WHERE EXTRACT (YEAR FROM release_date) = $1 ";
+            break;
+        case 'revenue':
+        case 'budget':
+        case 'runtime':
+        case 'popularity':
+        case 'vote_average':
+        case 'vote_count':
+            const lower = req.body.search * 0.9;
+            const upper = req.body.search * 1.1;
+            req.body.search.push(lower);
+            req.body.search.push(upper);
+            result = `SELECT * FROM movies_meta WHERE ${req.body.category} BETWEEN $2 AND $3 `
             break;
         default:
             // default query takes in a category and returning any record that contains the search value


### PR DESCRIPTION
API Feature:
Custom search previously did not know what to do if you selected a field that had a numerical input.

With this PR, any search involving a number queries the database looking for a value within 10% of that number. The main reason for this is because if you search for a budget, chances are the user is not going to exactly guess the budget on the dot. This helps alleviate that a bit.

This should now be able to handle pretty much anything @pakawaka1 's advanced search should throw at it.